### PR TITLE
[Bugfix] ensure_packages

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,2 @@
 source("renv/activate.R")
+source("R/utils.R")

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,0 @@
-root = true
-
-[*]
-end_of_line = lf
-indent_style = space
-
-[*.R]
-indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+
+[*.R]
+indent_size = 4

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,10 +4,10 @@
 ## Created: 2025-11-05                                                        ##
 ## Author: Dimitri Baptiste                                                   ##
 ## -----                                                                      ##
-## Last Modified: 2025-11-05                                                  ##
+## Last Modified: 2026-01-20                                                  ##
 ## Modified By: Dimitri Baptiste                                              ##
 ## -----                                                                      ##
-## Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  ##
+## Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             ##
 ################################################################################
 
 #' Ensure required packages are installed
@@ -16,13 +16,14 @@
 #' A method that installs packages from CRAN, if they're not yet installed in
 #' the current environment, and loads packages.
 #'
-#' @param packages Character vector of required packages
+#' @param ... Package names as strings
 #' @return A logical vector giving `TRUE` if the package is installed and
 #' available and `FALSE` if there was an issue with installing each of the
 #' specified packages
 #' @examples
-#' ensure_packages(c("dplyr", "here"))
-ensure_packages <- function(packages) {
+#' ensure_packages("dplyr", "here")
+ensure_packages <- function(...) {
+    packages <- c(...)
     return(vapply(
         packages,
         function(package) {
@@ -35,6 +36,6 @@ ensure_packages <- function(packages) {
             library(package, character.only = TRUE, warn.conflicts = FALSE)
             return(require(package, character.only = TRUE))
         },
-        logical(length(packages))
+        logical(1)
     ))
 }


### PR DESCRIPTION
## What does this PR do?
- Fixes an error in the `vapply()` in `ensure_packages()`
- Adds `.editorconfig` and ensures `R/utils.R` is always sourced. (cherry-picked from a stale branch)

## What Wrike task is this associated with?
N/A - Bugfix reported on Slack
