### PR TITLE
[Bugfix] Correct table rendering

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -97,14 +97,24 @@ h1.title, .title.h1 {
 // table style
 .table {
     // heading
-    & tr:first-of-type {
+    &:not(:has(.header)) tr:first-of-type {
         background-color: var(--bs-heading-color-dark);
         font-weight: 600;
         border-bottom: 2px solid;
-        border-color: inherit;
+        border-color: var(--bs-body-color);
 
-        & td {
-            color: black;
+    }
+
+    &:has(.header) {
+        .header {
+            background-color: var(--bs-heading-color-dark);
+            font-weight: 600;
+            border: 2px solid;
+            border-color: var(--bs-body-color);
+        }
+
+        tr th:not(:last-child), tbody tr td:not(:last-child) {
+            border-right: 2px solid;
         }
     }
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes an issue identified today in table rendering when there's an explicit header.

Example Quarto source:
```
| Drug Behavior | Proportion in 2018 | Proportion in 2022 |
|---------------|--------------------|--------------------|
| Former IDU    | 0.021056150        | 0.021111893        |
| Current IDU   | 0.005124777        | 0.005043397        |
| Never         | 0.973819073        | 0.973844710        |
: Drug Behavior Proportions {#tbl-behavior-prop1 tbl-colwidths=\["50, 50"\]}
```

## What Wrike task is this associated with?
https://www.wrike.com/open.htm?id=4356639222
