### PR TITLE
[Enhancements] Output Styling

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -157,7 +157,15 @@ pre:not(.sourceCode) {
         background: var(--bs-body-bg);
         font-family: sans-serif;
         font-weight: 600;
+    }
+
+    .cell-output-stdout &:before {
         content: " Output ";
+    }
+
+    .cell-output-stderr &:before {
+        content: " Warning/Error ";
+        color: var(--quarto-scss-export-syndemics-pink);
     }
 
     & code {


### PR DESCRIPTION
## What does this PR do?
This is a small change that makes code output correctly display whether it's from `stdout` ("Output") or `stderr` ("Warning/Error")

### Example
<img width="776" height="444" alt="image" src="https://github.com/user-attachments/assets/d24b4838-ce71-46d4-b7a1-61023507b89d" />

## What Wrike task is this associated with?
**N/A**
